### PR TITLE
fixed initialization sequence

### DIFF
--- a/Adafruit_CharacterOLED.cpp
+++ b/Adafruit_CharacterOLED.cpp
@@ -32,15 +32,19 @@
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-Adafruit_CharacterOLED::Adafruit_CharacterOLED(uint8_t rs, uint8_t rw, uint8_t enable,
+Adafruit_CharacterOLED::Adafruit_CharacterOLED(uint8_t ver, uint8_t rs, uint8_t rw, uint8_t enable,
 			     uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
 {
-  init(rs, rw, enable, d4, d5, d6, d7);
+  init(ver, rs, rw, enable, d4, d5, d6, d7);
 }
 
-void Adafruit_CharacterOLED::init(uint8_t rs, uint8_t rw, uint8_t enable,
+void Adafruit_CharacterOLED::init(uint8_t ver, uint8_t rs, uint8_t rw, uint8_t enable,
 			 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
 {
+  _oled_ver = ver;
+  if(_oled_ver != OLED_V1 && _oled_ver != OLED_V2) {
+    _oled_ver = OLED_V2; // if error, default to newer version
+  }
   _rs_pin = rs;
   _rw_pin = rw;
   _enable_pin = enable;
@@ -90,10 +94,12 @@ void Adafruit_CharacterOLED::begin(uint8_t cols, uint8_t lines)
   // reliably handle both warm & cold starts.
 
   // 4-Bit initialization sequence from Technobly
-  write4bits(0x03); // Put back in 8-bit mode
+  write4bits(0x03); // Put back into 8-bit mode
   delayMicroseconds(5000);
-  write4bits(0x08);
-  delayMicroseconds(5000);
+  if(_oled_ver == OLED_V2) {  // only run extra command for newer displays
+    write4bits(0x08);
+    delayMicroseconds(5000);
+  }
   write4bits(0x02); // Put into 4-bit mode
   delayMicroseconds(5000);
   write4bits(0x02);

--- a/Adafruit_CharacterOLED.h
+++ b/Adafruit_CharacterOLED.h
@@ -4,6 +4,10 @@
 #include <inttypes.h>
 #include "Print.h"
 
+// OLED hardware versions
+#define OLED_V1 0x01
+#define OLED_V2 0x02
+
 // commands
 #define LCD_CLEARDISPLAY 0x01
 #define LCD_RETURNHOME 0x02
@@ -45,10 +49,10 @@
 
 class Adafruit_CharacterOLED : public Print {
 public:
-  Adafruit_CharacterOLED(uint8_t rs, uint8_t rw, uint8_t enable,
+  Adafruit_CharacterOLED(uint8_t ver, uint8_t rs, uint8_t rw, uint8_t enable,
 		uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
   
-  void init(uint8_t rs, uint8_t rw, uint8_t enable,
+  void init(uint8_t ver, uint8_t rs, uint8_t rw, uint8_t enable,
 	    uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
     
   void begin(uint8_t cols, uint8_t rows);
@@ -80,6 +84,7 @@ private:
   void pulseEnable();
   void waitForReady();
 
+  uint8_t _oled_ver; // OLED_V1 = older, OLED_V2 = newer hardware version.
   uint8_t _rs_pin; // LOW: command.  HIGH: character.
   uint8_t _rw_pin; // LOW: write to LCD.  HIGH: read from LCD.
   uint8_t _enable_pin; // activated by a HIGH pulse.

--- a/examples/HelloOLEDWorld/HelloOLEDWorld.ino
+++ b/examples/HelloOLEDWorld/HelloOLEDWorld.ino
@@ -35,12 +35,14 @@
 // include the library code:
 #include <Adafruit_CharacterOLED.h>
 
-// initialize the library with the numbers of the interface pins
-Adafruit_CharacterOLED lcd(6, 7, 8, 9, 10, 11, 12);
+// initialize the library with the OLED hardware 
+// version OLED_Vx and numbers of the interface pins. 
+// OLED_V1 = older, OLED_V2 = newer. If 2 doesn't work try 1 ;)
+Adafruit_CharacterOLED lcd(OLED_V2, 6, 7, 8, 9, 10, 11, 12);
 
 void setup() 
 {
-    // Print a message to the LCD.
+  // Print a message to the LCD.
   lcd.begin(16, 2);
   lcd.print("hello OLED World");
 }
@@ -52,5 +54,4 @@ void loop()
   lcd.setCursor(0, 1);
   // print the number of seconds since reset:
   lcd.print(millis()/1000);
- }
-
+}


### PR DESCRIPTION
Hi Adafruit!  Please see this thread with all of the people having issues making the Winstar 16x2 OLED Character display work correctly.  Everyone was getting an "ax   ax" on their screens.  Turns out there was just a little issue with the initialization sequence.  Please see the full explanation of these changes here http://forums.adafruit.com/viewtopic.php?f=22&t=42179&p=218812#p218812

Now perhaps this will be fine going forward, but I have no way to test this with older displays that presumably worked with this library.  Hopefully it is backwards compatible.
