### PR TITLE
Bugfix: Remove default param re-definition

### DIFF
--- a/Adafruit_CharacterOLED.cpp
+++ b/Adafruit_CharacterOLED.cpp
@@ -18,15 +18,15 @@
 //    N="0": 1-line display
 //    F="0": 5 x 8 dot character font
 // 3. Power turn off
-//    PWR=”0”
+//    PWR=ï¿½0ï¿½
 // 4. Display on/off control: D="0": Display off C="0": Cursor off B="0": Blinking off
 // 5. Entry mode set
 //    I/D="1": Increment by 1
 //    S="0": No shift
 // 6. Cursor/Display shift/Mode / Pwr
-//    S/C=”0”, R/L=”1”: Shifts cursor position to the right
-//    G/C=”0”: Character mode
-//    Pwr=”1”: Internal DCDC power on
+//    S/C=ï¿½0ï¿½, R/L=ï¿½1ï¿½: Shifts cursor position to the right
+//    G/C=ï¿½0ï¿½: Character mode
+//    Pwr=ï¿½1ï¿½: Internal DCDC power on
 //
 // Note, however, that resetting the Arduino doesn't reset the LCD, so we
 // can't assume that its in that state when a sketch starts (and the
@@ -63,7 +63,7 @@ void Adafruit_CharacterOLED::init(uint8_t ver, uint8_t rs, uint8_t rw, uint8_t e
   begin(16, 2);  
 }
 
-void Adafruit_CharacterOLED::begin(uint8_t cols, uint8_t lines, uint8_t character_set = LCD_JAPANESE)
+void Adafruit_CharacterOLED::begin(uint8_t cols, uint8_t lines, uint8_t character_set)
 {
   _numlines = lines;
   _currline = 0;

--- a/Adafruit_CharacterOLED.cpp
+++ b/Adafruit_CharacterOLED.cpp
@@ -18,15 +18,15 @@
 //    N="0": 1-line display
 //    F="0": 5 x 8 dot character font
 // 3. Power turn off
-//    PWR=�0�
+//    PWR="0"
 // 4. Display on/off control: D="0": Display off C="0": Cursor off B="0": Blinking off
 // 5. Entry mode set
 //    I/D="1": Increment by 1
 //    S="0": No shift
 // 6. Cursor/Display shift/Mode / Pwr
-//    S/C=�0�, R/L=�1�: Shifts cursor position to the right
-//    G/C=�0�: Character mode
-//    Pwr=�1�: Internal DCDC power on
+//    S/C="0", R/L="1": Shifts cursor position to the right
+//    G/C="0": Character mode
+//    Pwr="1": Internal DCDC power on
 //
 // Note, however, that resetting the Arduino doesn't reset the LCD, so we
 // can't assume that its in that state when a sketch starts (and the


### PR DESCRIPTION
The default param for `::begin()` is already defined in the .h file, so it is safe to remove from the .cpp. `#include`s break on compilation otherwise.